### PR TITLE
Use Go 1.12 in go mods

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,4 +11,4 @@ require (
 	go.uber.org/zap v1.9.1
 )
 
-go 1.13
+go 1.12


### PR DESCRIPTION
Otel collector and related packages have not yet migrated to Go 1.13 so it would be nice if we didn't force it here.